### PR TITLE
Add: me-mory-api.is-a.dev domain

### DIFF
--- a/domains/me-mory-api.json
+++ b/domains/me-mory-api.json
@@ -1,0 +1,11 @@
+   {
+     "description": "Me-mory API backend",
+     "repo": "https://github.com/TeamZim/Zim_spring",
+     "owner": {
+       "username": "lee-yeonseo",
+       "email": "dlth010@naver.com"
+     },
+     "record": {
+       "A": ["54.174.34.81"]
+     }
+   }


### PR DESCRIPTION
 ## Domain Request
   
**Domain**: memory-api.is-a.dev
**Purpose**: Backend API for Memory travel diary application
**Repository**: https://github.com/TeamZim/Zim_spring
**IP Address**: 54.174.34.81 (AWS EC2)
   
 ## Project Description
Me-mory is a travel diary application that allows users to:
- Create and manage travel diaries
- Upload photos and audio recordings
- Track visited countries with emotions
- Share travel experiences
   
This domain will be used for the backend API server.
   
## Additional Information
- Team: Zim
- Development Stage: Active development
- Expected Usage: Production API server